### PR TITLE
Remove global variables in favor of closures

### DIFF
--- a/spec/mixed_required_arguments_spec.rb
+++ b/spec/mixed_required_arguments_spec.rb
@@ -2,18 +2,20 @@ require "spec_helper"
 require "curryable"
 
 RSpec.describe "Mixed required arguments" do
-  module Curryable::TestClasses
-    class MixedRequiredCommandClass
-      def initialize(a, b, c:, d:)
-        @a = a
-        @b = b
-        @c = c
-        @d = d
-      end
 
-      def call
-        $command_spy.call(a: @a, b: @b, c: @c, d: @d)
-      end
+  command_spy = nil
+
+  Curryable::TestClasses ||= Module.new
+  Curryable::TestClasses::MixedRequiredCommandClass = Class.new do
+    define_method(:initialize) do |a, b, c:, d:|
+      @a = a
+      @b = b
+      @c = c
+      @d = d
+    end
+
+    define_method(:call) do
+      command_spy.call(a: @a, b: @b, c: @c, d: @d)
     end
   end
 
@@ -21,7 +23,6 @@ RSpec.describe "Mixed required arguments" do
   let(:b) { double(:b) }
   let(:c) { double(:c) }
   let(:d) { double(:d) }
-  let(:command_spy) { spy }
 
   subject(:curryable) {
     Curryable.new(Curryable::TestClasses::MixedRequiredCommandClass)
@@ -30,7 +31,7 @@ RSpec.describe "Mixed required arguments" do
   let(:return_value) { double(:return_value) }
 
   before do
-    $command_spy = command_spy
+    command_spy = spy
 
     allow(command_spy).to receive(:call).and_return(return_value)
   end

--- a/spec/required_keyword_arguments_spec.rb
+++ b/spec/required_keyword_arguments_spec.rb
@@ -2,24 +2,25 @@ require "spec_helper"
 require "curryable"
 
 RSpec.describe "Required keyword arguments" do
-  module Curryable::TestClasses
-    class RequiredKeywordCommandClass
-      def initialize(a:, b:, c:)
-        @a = a
-        @b = b
-        @c = c
-      end
 
-      def call
-        $command_spy.call(a: @a, b: @b, c: @c)
-      end
+  command_spy = nil
+
+  Curryable::TestClasses ||= Module.new
+  Curryable::TestClasses::RequiredKeywordCommandClass = Class.new do
+    define_method(:initialize) do |a:, b:, c:|
+      @a = a
+      @b = b
+      @c = c
+    end
+
+    define_method(:call) do
+      command_spy.call(a: @a, b: @b, c: @c)
     end
   end
 
   let(:a) { double(:a) }
   let(:b) { double(:b) }
   let(:c) { double(:c) }
-  let(:command_spy) { spy }
 
   subject(:curryable) {
     Curryable.new(Curryable::TestClasses::RequiredKeywordCommandClass)
@@ -28,7 +29,7 @@ RSpec.describe "Required keyword arguments" do
   let(:return_value) { double(:return_value) }
 
   before do
-    $command_spy = command_spy
+    command_spy = spy
 
     allow(command_spy).to receive(:call).and_return(return_value)
   end

--- a/spec/required_positional_arguments_spec.rb
+++ b/spec/required_positional_arguments_spec.rb
@@ -2,24 +2,25 @@ require "spec_helper"
 require "curryable"
 
 RSpec.describe "Required positional arguments" do
-  module Curryable::TestClasses
-    class RequiredPositionalCommandClass
-      def initialize(a, b, c)
-        @a = a
-        @b = b
-        @c = c
-      end
 
-      def call
-        $command_spy.call(a: @a, b: @b, c: @c)
-      end
+  command_spy = nil
+
+  Curryable::TestClasses ||= Module.new
+  Curryable::TestClasses::RequiredPositionalCommandClass = Class.new do
+    define_method(:initialize) do |a, b, c|
+      @a = a
+      @b = b
+      @c = c
+    end
+
+    define_method(:call) do
+      command_spy.call(a: @a, b: @b, c: @c)
     end
   end
 
   let(:a) { double(:a) }
   let(:b) { double(:b) }
   let(:c) { double(:c) }
-  let(:command_spy) { spy }
 
   subject(:curryable) {
     Curryable.new(Curryable::TestClasses::RequiredPositionalCommandClass)
@@ -28,7 +29,7 @@ RSpec.describe "Required positional arguments" do
   let(:return_value) { double(:return_value) }
 
   before do
-    $command_spy = command_spy
+    command_spy = spy
 
     allow(command_spy).to receive(:call).and_return(return_value)
   end


### PR DESCRIPTION
In order for our `command_spy` to be in scope in both our dummy classes
and our tests we thought the only easy way would be to make it global.
RSpec however has the virtue of making heavy use of block and closures.
This change attempts to leverage Ruby's lexical scoping to fight the war
against global vars.

Dollar signs are gross anyway is this PHP or something?

Check these out:
* http://myronmars.to/n/dev-blog/2012/10/using-closures-to-avoid-leaking-state
* https://github.com/bestie/objective-ruby-style-guide